### PR TITLE
http://schema.org/WebPage not needed anymore

### DIFF
--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -1,4 +1,4 @@
 
-<div class="tx-jpfaq" id="tx-jpfaq{currentUid}" itemscope itemtype="http://schema.org/WebPage http://schema.org/FAQPage">
+<div class="tx-jpfaq" id="tx-jpfaq{currentUid}" itemscope itemtype="http://schema.org/FAQPage">
 	<f:render section="main" />
 </div>


### PR DESCRIPTION
http://schema.org/WebPage is not needed anymore since http://schema.org/FAQPage is part of the core vocabulary.