### PR TITLE
implement thumbs using a form instead of links

### DIFF
--- a/Resources/Private/Partials/Question/Helpfulness.html
+++ b/Resources/Private/Partials/Question/Helpfulness.html
@@ -1,20 +1,22 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
     <div class="jpfaqQuestionCommentContainer{question.uid} jpfaqQuestionCommentContainer">
-        <p class="jpfaqQuestionHelpfulText">
-            <f:translate key="tx_jpfaq_domain_model_question.helpfulText"/>
+        <form>
+            <p class="jpfaqQuestionHelpfulText">
+                <f:translate key="tx_jpfaq_domain_model_question.helpfulText"/>
 
-            <f:link.action action="helpfulness" arguments="{question:question, helpful:1, pluginUid:currentUid}"
-                           class="jpfaqQuestionHelpful"
-                           additionalAttributes="{f:if(condition:'{gtag.enable}', then: '{data-gtagevent: gtag.event, data-gtagcategory: gtag.category, data-gtaglabel: question.question, data-gtagvalue: gtag.valueHelpful}', else: '{data:0}')}">
-                <f:translate key="tx_jpfaq_domain_model_question.helpful"/>
-            </f:link.action>
-            /
-            <f:link.action action="helpfulness" arguments="{question:question, helpful:0, pluginUid:currentUid}"
-                           class="jpfaqQuestionNotHelpful"
-                           additionalAttributes="{f:if(condition:'{gtag.enable}', then: '{data-gtagevent: gtag.event, data-gtagcategory: gtag.category, data-gtaglabel: question.question, data-gtagvalue: gtag.valueUnhelpful}', else: '{data:0}')}">
-                <f:translate key="tx_jpfaq_domain_model_question.notHelpful"/>
-            </f:link.action>
-        </p>
+                <f:form.button type="submit" class="jpfaqQuestionHelpful"
+                               formaction="{f:uri.action(action: 'helpfulness', arguments: {question:question, helpful:1, pluginUid:currentUid})}"
+                               additionalAttributes="{f:if(condition:'{gtag.enable}', then: '{data-gtagevent: gtag.event, data-gtagcategory: gtag.category, data-gtaglabel: question.question, data-gtagvalue: gtag.valueHelpful}', else: '{data:0}')}">
+                    <f:translate key="tx_jpfaq_domain_model_question.helpful"/>
+                </f:form.button>
+                /
+                <f:form.button type="submit" class="jpfaqQuestionHelpful"
+                               formaction="{f:uri.action(action: 'helpfulness', arguments: {question:question, helpful:0, pluginUid:currentUid})}"
+                               additionalAttributes="{f:if(condition:'{gtag.enable}', then: '{data-gtagevent: gtag.event, data-gtagcategory: gtag.category, data-gtaglabel: question.question, data-gtagvalue: gtag.valueUnhelpful}', else: '{data:0}')}">
+                    <f:translate key="tx_jpfaq_domain_model_question.notHelpful"/>
+                </f:form.button>
+            </p>
+        </form>
 
         <div class="jpfaqAddCommentForm"></div>
     </div>

--- a/Resources/Public/Javascript/jpFaq.js
+++ b/Resources/Public/Javascript/jpFaq.js
@@ -159,13 +159,14 @@ var jpFaq = jpFaq || {};
         questionIsHelpful: function () {
             $(jpfaqQuestionHelpful).click(function (event) {
                 event.preventDefault();
-                $(this).closest(jpfaqQuestionHelpfulText).hide();
+                var $link = $(this);
+                $link.closest(jpfaqQuestionHelpfulText).hide();
 
-                var loadUri = $(this).attr('href') + jpfaqCommentPageType;
-                var contentContainer = $(this).closest(jpfaqQuestionCommentContainer);
+                var loadUri = ($link.attr('href') || $link.attr('formaction')) + jpfaqCommentPageType;
+                var contentContainer = $link.closest(jpfaqQuestionCommentContainer);
                 jpFaq.Main.ajaxPost(loadUri, contentContainer);
 
-                var gtagData = $(this).data();
+                var gtagData = $link.data();
                 if (gtagData['gtagevent']) {
                     jpFaq.Main.sendGtag(gtagData);
                 }
@@ -185,14 +186,15 @@ var jpFaq = jpFaq || {};
         questionIsNotHelpful: function () {
             $(jpfaqQuestionNotHelpful).click(function (event) {
                 event.preventDefault();
-                $(this).closest(jpfaqQuestionHelpfulText).hide();
+                let $link = $(this);
+                $link.closest(jpfaqQuestionHelpfulText).hide();
 
-                var loadUri = $(this).attr('href') + jpfaqCommentPageType;
-                var contentContainer = $(this).closest(jpfaqQuestionCommentContainer).find(jpfaqAddCommentForm);
+                var loadUri = ($link.attr('href') || $link.attr('formaction')) + jpfaqCommentPageType;
+                var contentContainer = $link.closest(jpfaqQuestionCommentContainer).find(jpfaqAddCommentForm);
 
                 jpFaq.Main.ajaxPost(loadUri, contentContainer);
 
-                var gtagData = $(this).data();
+                var gtagData = $link.data();
                 if (gtagData['gtagevent']) {
                     jpFaq.Main.sendGtag(gtagData);
                 }


### PR DESCRIPTION
Liking a question is not a GET action.

Having the link there results in all sorts of unwanted side effects:
- google and other bots will crawl the url, resulting in wrong counts.
- google and other search engines might directly link to up/downvoted pages.
- these urls will output the entire page, resulting in duplicate content.

Using a form resolves all these issues. The GET url still exists but there isn't any obvious way to it. I could have added an exception in the controller but that would break pages that still use the old template.

In typo3 9, it would also be possible to exclude all necessary parameters from the canonical url which would further reduce the chance of duplicate content.