### PR TITLE
[TASK] Add extension key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,10 @@
   "replace": {
     "jpfaq": "self.version",
     "typo3-ter/jpfaq": "self.version"
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "jpfaq"
+    }
   }
 }


### PR DESCRIPTION
Specifying the extension key in the composer json extra section will be mandatory in future TYPO3 versions.