### PR TITLE
[BUGFIX] TypoScript for TYPO3 v11 and PHP 8

### DIFF
--- a/Configuration/TsConfig/Page/pageTSconfig.tsconfig
+++ b/Configuration/TsConfig/Page/pageTSconfig.tsconfig
@@ -1,6 +1,6 @@
 # Choose in backend sysfolder with FAQ articles "Contains Plugin" and set on jpFAQ!
 
-[page["module"] == "jpfaq"]
+[traverse(page, 'module') == "jpfaq"]
     TCEFORM {
         tt_content {
             # Hide columns

--- a/Configuration/TsConfig/includePageTSconfig.tsconfig
+++ b/Configuration/TsConfig/includePageTSconfig.tsconfig
@@ -1,1 +1,2 @@
-<INCLUDE_TYPOSCRIPT: source="DIR: EXT:jpfaq/Configuration/TsConfig/Page/" extension="tsconfig">
+@import 'EXT:jpfaq/Configuration/TsConfig/Page/contentElementWizard.tsconfig'
+@import 'EXT:jpfaq/Configuration/TsConfig/Page/pageTSconfig.tsconfig'


### PR DESCRIPTION
* Condition uses `traverse()` to avoid undefined array key errors
* Replace old import with `@import` syntax