### PR TITLE
feat: add index to tt_content

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -13,7 +13,9 @@ CREATE TABLE tx_jpfaq_domain_model_question (
 
 # IRRE Records
 CREATE TABLE tt_content (
-    jpfaq int(11) unsigned DEFAULT '0' NOT NULL
+    jpfaq int(11) unsigned DEFAULT '0' NOT NULL,
+
+    KEY jpfaq_content (jpfaq)
 );
 
 #


### PR DESCRIPTION
When using "Answer additional content [additional_content_answer]" a query like this is performed:
```sql
SELECT `tt_content`.*
FROM `tt_content` `tt_content`
WHERE (`tt_content`.`jpfaq` = 123) AND ....
```
On our server, such a query takes approximately 2.8 seconds. The tt_content table contains around 500k entries. Using an index key reduces the time to 0.01 seconds.